### PR TITLE
FEAT: pre-push훅 추가

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,14 @@
+
+echo "Running pre-push hook..."
+
+# main branch 에 바로 푸시하는 것을 방지합니다
+main_ref="refs/heads/main"
+
+if read local_ref local_sha remote_ref remote_sh
+then
+    if [ "$remote_ref" == "$main_ref" ]
+    then
+        echo "Pushing to the main branch is not allowed."
+        exit 1
+    fi
+fi


### PR DESCRIPTION
실수로 main 브랜치에 직접 push 하는 것을 방지하기 위해 pre-push hook 을 추가했습니다.
main 브랜치는 PR 을 통해서만 병합되도록 보호합니다.