### PR TITLE
Feat: 더보기 페이지 디자인

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import Regitster_done from "./pages/Auth/Register/DonePage";
 // 메인 페이지
 import MainPage from "./pages/RightPages/MyPage/MainPage/MainPage";
 import CompanyMorePage from "./pages/RightPages/MyPage/MorePage/CompanyMorePage";
+import ProjectMorePage from "./pages/RightPages/MyPage/MorePage/ProjectMorePage";
 
 // 채팅
 import ChatMainPage from "./pages/RightPages/ChatPage/Main/ChatMainPage";
@@ -38,6 +39,7 @@ function App() {
           {/* 메인페이지 */}
           <Route path="/mypage/main" element={<MainPage />} />
           <Route path="/mypage/company" element={<CompanyMorePage />} />
+          <Route path="/mypage/project" element={<ProjectMorePage />} />
 
           {/* 채팅 */}
           <Route path="/chat" element={<ChatMainPage />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import Regitster_done from "./pages/Auth/Register/DonePage";
 
 // 메인 페이지
 import MainPage from "./pages/RightPages/MyPage/MainPage/MainPage";
+import CompanyMorePage from "./pages/RightPages/MyPage/MorePage/CompanyMorePage";
 
 // 채팅
 import ChatMainPage from "./pages/RightPages/ChatPage/Main/ChatMainPage";
@@ -36,6 +37,7 @@ function App() {
 
           {/* 메인페이지 */}
           <Route path="/mypage/main" element={<MainPage />} />
+          <Route path="/mypage/company" element={<CompanyMorePage />} />
 
           {/* 채팅 */}
           <Route path="/chat" element={<ChatMainPage />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import Regitster_done from "./pages/Auth/Register/DonePage";
 import MainPage from "./pages/RightPages/MyPage/MainPage/MainPage";
 import CompanyMorePage from "./pages/RightPages/MyPage/MorePage/CompanyMorePage";
 import ProjectMorePage from "./pages/RightPages/MyPage/MorePage/ProjectMorePage";
+import AlgorithmMorePage from "./pages/RightPages/MyPage/MorePage/AlgorithmMorePage";
 
 // 채팅
 import ChatMainPage from "./pages/RightPages/ChatPage/Main/ChatMainPage";
@@ -40,6 +41,7 @@ function App() {
           <Route path="/mypage/main" element={<MainPage />} />
           <Route path="/mypage/company" element={<CompanyMorePage />} />
           <Route path="/mypage/project" element={<ProjectMorePage />} />
+          <Route path="/mypage/algorithm" element={<AlgorithmMorePage />} />
 
           {/* 채팅 */}
           <Route path="/chat" element={<ChatMainPage />} />

--- a/src/pages/LeftPages/AlgorithmPage/AlgoLeft.tsx
+++ b/src/pages/LeftPages/AlgorithmPage/AlgoLeft.tsx
@@ -1,70 +1,29 @@
-import clsx from "clsx";
-import { FaLongArrowAltLeft, FaLongArrowAltRight } from "react-icons/fa";
-import { GiHamburgerMenu } from "react-icons/gi";
-import {
-  Sidebar,
-  useSidebar,
-} from "../../../layouts/SidebarLayout/SidebarLayout";
 import styles from "./AlgoLeft.module.css";
-import LogoDemo from "../../../../public/LogoDemo.png";
+import LeftPart from "../../../layouts/Components/LeftPart"; //왼쪽 부분 컴포넌트
 import Input from "../../../components/Input/Input";
 // import Button from "../../../components/Button/Button";
 
 const AlgoLeft = () => {
-  const { isOpen } = useSidebar();
-
   return (
-    <div className={styles.sidebar}>
-      <div className={clsx(styles.top_section, isOpen && styles.open)}>
-        <div className={styles.menu}>
-          <div className={styles.icon_box}>
-            <GiHamburgerMenu size={28} />
+    <LeftPart>
+      <div className={styles.container}>
+        <div className={styles.select_header}></div>
+        <div className={styles.content_box}>
+          <div className={styles.input_box}>
+            <p>회사 선택</p>
+            <Input
+              style={{
+                boxSizing: "border-box",
+                width: "100%",
+              }}
+            />
           </div>
 
-          {isOpen && (
-            <div className={styles.logo_box}>
-              <img src={LogoDemo} alt="Logo" className={styles.logo} />
-            </div>
-          )}
+          <Input />
+          <Input />
         </div>
-
-        <Sidebar.ToggleButton className={styles.toggle_button}>
-          {(isOpen) =>
-            isOpen ? (
-              <div className={styles.icon_box}>
-                <FaLongArrowAltLeft size={20} />
-                <p>접기</p>
-              </div>
-            ) : (
-              <div className={styles.icon_box}>
-                <FaLongArrowAltRight size={20} />
-                <p>열기</p>
-              </div>
-            )
-          }
-        </Sidebar.ToggleButton>
       </div>
-
-      {isOpen && (
-        <div className={styles.container}>
-          <div className={styles.select_header}></div>
-          <div className={styles.content_box}>
-            <div className={styles.input_box}>
-              <p>회사 선택</p>
-              <Input
-                style={{
-                  boxSizing: "border-box",
-                  width: "100%",
-                }}
-              />
-            </div>
-
-            <Input />
-            <Input />
-          </div>
-        </div>
-      )}
-    </div>
+    </LeftPart>
   );
 };
 

--- a/src/pages/RightPages/MyPage/Components/CompanyBox/FullCompanyBox.module.css
+++ b/src/pages/RightPages/MyPage/Components/CompanyBox/FullCompanyBox.module.css
@@ -1,0 +1,42 @@
+.company_item{
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    background-color: var(--color-project-back);
+    padding: 1rem;
+    padding-bottom: 0.7rem;
+    border-radius: var(--radius-sm);
+    min-width: fit-content;
+}
+
+.thumbnail {
+    width: 7rem;
+    border-radius: var(--radius-full);
+    cursor: pointer;
+}
+
+.name {
+    margin: 0.5rem;
+    width: 100%;
+    word-wrap: break-word;
+    text-align: center;
+    color: var(--color-text-primary);
+    cursor: text;
+    font-weight: var(--font-weight-bold);
+}
+
+.button_list {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    flex-grow: 1;
+}
+
+
+.button_list Button {
+    margin: 0.3rem;
+    width: 100%;
+    font-size: var(--text-sm);
+    min-width: fit-content;
+    white-space: nowrap;
+} 

--- a/src/pages/RightPages/MyPage/Components/CompanyBox/FullCompanyBox.tsx
+++ b/src/pages/RightPages/MyPage/Components/CompanyBox/FullCompanyBox.tsx
@@ -1,0 +1,37 @@
+import { useNavigate } from "react-router-dom";
+import styles from "./FullCompanyBox.module.css";
+
+import Button from "../../../../../components/Button/Button";
+
+interface FullCompanyBoxProps {
+  id: number;
+  thumbnail: string;
+  name: string;
+  onHandle: (id: number, isFavorite: boolean) => void;
+  isFavorite: boolean;
+}
+
+export default function FullCompanyBox({
+  id,
+  thumbnail,
+  name,
+  onHandle,
+  isFavorite,
+}: FullCompanyBoxProps) {
+  const navigate = useNavigate();
+  const handleNavi = () => navigate(`/company/${id}`);
+  const handleAction = () => onHandle(id, isFavorite);
+
+  return (
+    <div className={styles.company_item}>
+      <img className={styles.thumbnail} src={thumbnail} />
+      <p className={styles.name}>{name}</p>
+      <div className={styles.button_list}>
+        <Button onClick={handleNavi}>기업 정보 보기</Button>
+        <Button onClick={handleAction}>
+          {isFavorite ? "관심 기업에서 삭제" : "관심 기업에 추가"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/RightPages/MyPage/MainPage/MainPage.module.css
+++ b/src/pages/RightPages/MyPage/MainPage/MainPage.module.css
@@ -1,3 +1,8 @@
+.container{
+    container-type: inline-size; 
+    container-name: left_container;
+}
+
 .companySection, .projectSection, .algorithmSection{
     padding: 1rem 2rem;
 }
@@ -43,20 +48,14 @@
     padding: 1rem;
 }
 
-@media (min-width: 720px) {
-    .projectList, .algorithmList{
+@container left_container (min-width: 600px) {
+    .projectList, .algorithmList {
         grid-template-columns: repeat(2, 1fr);
     }
 }
 
-@media (min-width: 1296px) {
-    .projectList, .algorithmList{
+@container left_container (min-width: 900px) {
+    .projectList, .algorithmList {
         grid-template-columns: repeat(3, 1fr);
-    }
-}
-
-@media (min-width: 1440px) {
-    .projectList, .algorithmList{
-        grid-template-columns: repeat(4, 1fr);
     }
 }

--- a/src/pages/RightPages/MyPage/MainPage/MainPage.module.css
+++ b/src/pages/RightPages/MyPage/MainPage/MainPage.module.css
@@ -14,6 +14,15 @@
     font-family: var(--font-general);
 }
 
+.no_data {
+    width: 100%;
+    padding: 3rem;
+    text-align: center;
+    line-height: 1.5rem;
+    color: var(--color-text-sub);
+    font-size: var(--text-lg);
+}
+
 .companyList {
     width: 100%;
     margin: 1rem 0.5rem;

--- a/src/pages/RightPages/MyPage/MainPage/MainPage.tsx
+++ b/src/pages/RightPages/MyPage/MainPage/MainPage.tsx
@@ -14,10 +14,16 @@ import SimpleCompanyBox from "../Components/CompanyBox/SimpleCompanyBox";
 import ProjectBox from "../Components/ProjectBox/ProjectBox";
 import AlgorithmBox from "../Components/AlgorithmBox/AlgorithmBox";
 const MainPage = () => {
-  const companies = ["네이버", "카카오", "라인", "쿠팡", "배민", "구름"];
   const projectContents =
     "이것은 구름 딥다이브의 지정 프로젝트인 Web IDE 개발을 위한 디자인입니다. ";
   const langs = ["Python", "C/C++", "JavaScript", "C#", "Go"];
+
+  // const companies = ["네이버", "카카오", "라인", "쿠팡", "배민", "구름"];
+  // const projects = ["구름 프로젝트", "구름구름 프로젝트", "프로젝트 이름"];
+  // const algorithms = ["네이버 대비 알고리즘", "알고리즘 연습", "PS 연습"]
+  const companies = [];
+  const projects = [];
+  const algorithms = [];
 
   return (
     <BaseLayout>
@@ -32,16 +38,24 @@ const MainPage = () => {
             <Button className={styles.companyMore}>
               <BsPinAngleFill /> 관심 기업 <AiOutlineDoubleRight />
             </Button>
-            <div className={styles.companyList}>
-              {companies.map((company, i) => (
-                <SimpleCompanyBox
-                  key={"company" + i}
-                  id={i + 1}
-                  thumbnail="/logo_goorm.png"
-                  name={company}
-                />
-              ))}
-            </div>
+            {companies.length > 0 ? (
+              <div className={styles.companyList}>
+                {companies.map((company, i) => (
+                  <SimpleCompanyBox
+                    key={"company" + i}
+                    id={i + 1}
+                    thumbnail="/logo_goorm.png"
+                    name={company}
+                  />
+                ))}
+              </div>
+            ) : (
+              <p className={styles.no_data}>
+                관심 기업이 없습니다.
+                <br />
+                관심 기업을 추가해보세요!
+              </p>
+            )}
           </section>
 
           {/* 프로젝트 정보 */}
@@ -49,38 +63,54 @@ const MainPage = () => {
             <Button className={styles.projectMore}>
               <BsPinAngleFill /> 대표 프로젝트 <AiOutlineDoubleRight />
             </Button>
-            <div className={styles.projectList}>
-              {[...Array(4)].map((_, i) => (
-                <ProjectBox
-                  id={i}
-                  key={"project" + i}
-                  title={`${i + 1}번째 프로젝트 제목`}
-                  contents={projectContents.repeat(i + 1)}
-                  lang={langs[i]}
-                />
-              ))}
-            </div>
+            {projects.length > 0 ? (
+              <div className={styles.projectList}>
+                {projects.map((project, i) => (
+                  <ProjectBox
+                    id={i}
+                    key={"project" + i}
+                    title={project}
+                    contents={projectContents.repeat(i + 1)}
+                    lang={langs[i]}
+                  />
+                ))}
+              </div>
+            ) : (
+              <p className={styles.no_data}>
+                대표 프로젝트가 없습니다
+                <br />
+                깃허브에서 새로운 프로젝트를 불러와보세요!
+              </p>
+            )}
           </section>
 
-          {/* 프로젝트 정보 */}
+          {/* 알고리즘 정보 */}
           <section className={styles.algorithmSection}>
             <Button className={styles.algorithmMore}>
               <BsPinAngleFill /> 알고리즘 문제 <AiOutlineDoubleRight />
             </Button>
-            <div className={styles.algorithmList}>
-              {[...Array(5)].map((_, i) => (
-                <AlgorithmBox
-                  id={i + 1}
-                  key={"project" + i}
-                  title={companies[i] + " 대비 알고리즘 " + (i + 1) + " 일차"}
-                  problems={["No 9995. 숫자 세기", "No 9995. 숫자 세기"]}
-                  duration={60}
-                  problemCount={2 * (i + 1)}
-                  lang={langs[i]}
-                  levelImg="/level_5.png"
-                />
-              ))}
-            </div>
+            {algorithms.length > 0 ? (
+              <div className={styles.algorithmList}>
+                {algorithms.map((algorithm, i) => (
+                  <AlgorithmBox
+                    id={i + 1}
+                    key={"project" + i}
+                    title={algorithm}
+                    problems={["No 9995. 숫자 세기", "No 9995. 숫자 세기"]}
+                    duration={60}
+                    problemCount={2 * (i + 1)}
+                    lang={langs[i]}
+                    levelImg="/level_5.png"
+                  />
+                ))}
+              </div>
+            ) : (
+              <p className={styles.no_data}>
+                코딩 테스트 기록이 없습니다.
+                <br />
+                알고리즘 문제를 풀고 새로운 성장을 시작해보세요!
+              </p>
+            )}
           </section>
         </Sidebar.Content>
       </Sidebar.Provider>

--- a/src/pages/RightPages/MyPage/MainPage/MainPage.tsx
+++ b/src/pages/RightPages/MyPage/MainPage/MainPage.tsx
@@ -22,12 +22,9 @@ const MainPage = () => {
     "이것은 구름 딥다이브의 지정 프로젝트인 Web IDE 개발을 위한 디자인입니다. ";
   const langs = ["Python", "C/C++", "JavaScript", "C#", "Go"];
 
-  // const companies = ["네이버", "카카오", "라인", "쿠팡", "배민", "구름"];
-  // const projects = ["구름 프로젝트", "구름구름 프로젝트", "프로젝트 이름"];
-  // const algorithms = ["네이버 대비 알고리즘", "알고리즘 연습", "PS 연습"]
-  const companies = [];
-  const projects = [];
-  const algorithms = [];
+  const companies = ["네이버", "카카오", "라인", "쿠팡", "배민", "구름"];
+  const projects = ["구름 프로젝트", "구름구름 프로젝트", "프로젝트 이름"];
+  const algorithms = ["네이버 대비 알고리즘", "알고리즘 연습", "PS 연습"];
 
   // 더보기 페이지 이동
   const handleNaviCompany = () => navigate(`/mypage/company`);
@@ -42,88 +39,96 @@ const MainPage = () => {
         </Sidebar.Panel>
 
         <Sidebar.Content header={<BasicHeader />}>
-          {/* 기업 정보 */}
-          <section className={styles.companySection}>
-            <Button className={styles.companyMore} onClick={handleNaviCompany}>
-              <BsPinAngleFill /> 관심 기업 <AiOutlineDoubleRight />
-            </Button>
-            {companies.length > 0 ? (
-              <div className={styles.companyList}>
-                {companies.map((company, i) => (
-                  <SimpleCompanyBox
-                    key={"company" + i}
-                    id={i + 1}
-                    thumbnail="/logo_goorm.png"
-                    name={company}
-                  />
-                ))}
-              </div>
-            ) : (
-              <p className={styles.no_data}>
-                관심 기업이 없습니다.
-                <br />
-                관심 기업을 추가해보세요!
-              </p>
-            )}
-          </section>
+          <div className={styles.container}>
+            {/* 기업 정보 */}
+            <section className={styles.companySection}>
+              <Button
+                className={styles.companyMore}
+                onClick={handleNaviCompany}
+              >
+                <BsPinAngleFill /> 관심 기업 <AiOutlineDoubleRight />
+              </Button>
+              {companies.length > 0 ? (
+                <div className={styles.companyList}>
+                  {companies.map((company, i) => (
+                    <SimpleCompanyBox
+                      key={"company" + i}
+                      id={i + 1}
+                      thumbnail="/logo_goorm.png"
+                      name={company}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <p className={styles.no_data}>
+                  관심 기업이 없습니다.
+                  <br />
+                  관심 기업을 추가해보세요!
+                </p>
+              )}
+            </section>
 
-          {/* 프로젝트 정보 */}
-          <section className={styles.projectSection}>
-            <Button className={styles.projectMore} onClick={handleNaviProject}>
-              <BsPinAngleFill /> 대표 프로젝트 <AiOutlineDoubleRight />
-            </Button>
-            {projects.length > 0 ? (
-              <div className={styles.projectList}>
-                {projects.map((project, i) => (
-                  <ProjectBox
-                    id={i}
-                    key={"project" + i}
-                    title={project}
-                    contents={projectContents.repeat(i + 1)}
-                    lang={langs[i]}
-                  />
-                ))}
-              </div>
-            ) : (
-              <p className={styles.no_data}>
-                대표 프로젝트가 없습니다
-                <br />
-                깃허브에서 새로운 프로젝트를 불러와보세요!
-              </p>
-            )}
-          </section>
+            {/* 프로젝트 정보 */}
+            <section className={styles.projectSection}>
+              <Button
+                className={styles.projectMore}
+                onClick={handleNaviProject}
+              >
+                <BsPinAngleFill /> 대표 프로젝트 <AiOutlineDoubleRight />
+              </Button>
+              {projects.length > 0 ? (
+                <div className={styles.projectList}>
+                  {projects.map((project, i) => (
+                    <ProjectBox
+                      id={i}
+                      key={"project" + i}
+                      title={project}
+                      contents={projectContents.repeat(i + 1)}
+                      lang={langs[i]}
+                    />
+                  ))}
+                </div>
+              ) : (
+                <p className={styles.no_data}>
+                  대표 프로젝트가 없습니다
+                  <br />
+                  깃허브에서 새로운 프로젝트를 불러와보세요!
+                </p>
+              )}
+            </section>
 
-          {/* 알고리즘 정보 */}
-          <section className={styles.algorithmSection}>
-            <Button
-              className={styles.algorithmMore}
-              onClick={handleNaviAlgorithm}
-            >
-              <BsPinAngleFill /> 알고리즘 문제 <AiOutlineDoubleRight />
-            </Button>
-            {algorithms.length > 0 ? (
-              <div className={styles.algorithmList}>
-                {algorithms.map((algorithm, i) => (
-                  <AlgorithmBox
-                    id={i + 1}
-                    key={"project" + i}
-                    title={algorithm}
-                    problems={["No 9995. 숫자 세기", "No 9995. 숫자 세기"]}
-                    duration={60}
-                    problemCount={2 * (i + 1)}
-                    lang={langs[i]}
-                    levelImg="/level_5.png"
-                  />
-                ))}
-              </div>
-            ) : (
-              <p className={styles.no_data}>
-                코딩 테스트 기록이 없습니다.
-                <br />
-                알고리즘 문제를 풀고 새로운 성장을 시작해보세요!
-              </p>
-            )}
-          </section>
+            {/* 알고리즘 정보 */}
+            <section className={styles.algorithmSection}>
+              <Button
+                className={styles.algorithmMore}
+                onClick={handleNaviAlgorithm}
+              >
+                <BsPinAngleFill /> 알고리즘 문제 <AiOutlineDoubleRight />
+              </Button>
+              {algorithms.length > 0 ? (
+                <div className={styles.algorithmList}>
+                  {algorithms.map((algorithm, i) => (
+                    <AlgorithmBox
+                      id={i + 1}
+                      key={"project" + i}
+                      title={algorithm}
+                      problems={["No 9995. 숫자 세기", "No 9995. 숫자 세기"]}
+                      duration={60}
+                      problemCount={2 * (i + 1)}
+                      lang={langs[i]}
+                      levelImg="/level_5.png"
+                    />
+                  ))}
+                </div>
+              ) : (
+                <p className={styles.no_data}>
+                  코딩 테스트 기록이 없습니다.
+                  <br />
+                  알고리즘 문제를 풀고 새로운 성장을 시작해보세요!
+                </p>
+              )}
+            </section>
+          </div>
         </Sidebar.Content>
       </Sidebar.Provider>
     </BaseLayout>

--- a/src/pages/RightPages/MyPage/MainPage/MainPage.tsx
+++ b/src/pages/RightPages/MyPage/MainPage/MainPage.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from "react-router-dom";
 import { Sidebar } from "../../../../layouts/SidebarLayout/SidebarLayout";
 import BasicHeader from "../../../../layouts/Components/BasicHeader";
 import BaseLayout from "../../../../layouts/BaseLayout/BaseLayout";
@@ -13,7 +14,10 @@ import Button from "../../../../components/Button/Button";
 import SimpleCompanyBox from "../Components/CompanyBox/SimpleCompanyBox";
 import ProjectBox from "../Components/ProjectBox/ProjectBox";
 import AlgorithmBox from "../Components/AlgorithmBox/AlgorithmBox";
+
 const MainPage = () => {
+  const navigate = useNavigate();
+
   const projectContents =
     "이것은 구름 딥다이브의 지정 프로젝트인 Web IDE 개발을 위한 디자인입니다. ";
   const langs = ["Python", "C/C++", "JavaScript", "C#", "Go"];
@@ -25,6 +29,11 @@ const MainPage = () => {
   const projects = [];
   const algorithms = [];
 
+  // 더보기 페이지 이동
+  const handleNaviCompany = () => navigate(`/mypage/company`);
+  const handleNaviProject = () => navigate(`/mypage/project`);
+  const handleNaviAlgorithm = () => navigate(`/mypage/algorithm`);
+
   return (
     <BaseLayout>
       <Sidebar.Provider>
@@ -35,7 +44,7 @@ const MainPage = () => {
         <Sidebar.Content header={<BasicHeader />}>
           {/* 기업 정보 */}
           <section className={styles.companySection}>
-            <Button className={styles.companyMore}>
+            <Button className={styles.companyMore} onClick={handleNaviCompany}>
               <BsPinAngleFill /> 관심 기업 <AiOutlineDoubleRight />
             </Button>
             {companies.length > 0 ? (
@@ -60,7 +69,7 @@ const MainPage = () => {
 
           {/* 프로젝트 정보 */}
           <section className={styles.projectSection}>
-            <Button className={styles.projectMore}>
+            <Button className={styles.projectMore} onClick={handleNaviProject}>
               <BsPinAngleFill /> 대표 프로젝트 <AiOutlineDoubleRight />
             </Button>
             {projects.length > 0 ? (
@@ -86,7 +95,10 @@ const MainPage = () => {
 
           {/* 알고리즘 정보 */}
           <section className={styles.algorithmSection}>
-            <Button className={styles.algorithmMore}>
+            <Button
+              className={styles.algorithmMore}
+              onClick={handleNaviAlgorithm}
+            >
               <BsPinAngleFill /> 알고리즘 문제 <AiOutlineDoubleRight />
             </Button>
             {algorithms.length > 0 ? (

--- a/src/pages/RightPages/MyPage/MorePage/AlgorithmMorePage.module.css
+++ b/src/pages/RightPages/MyPage/MorePage/AlgorithmMorePage.module.css
@@ -1,0 +1,54 @@
+.algorithmSection{
+    padding: 1rem 2rem;
+}
+
+.algorithmMore{
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.5rem;
+    
+    color: var(--color-text-primary);
+    font-size: var(--text-base);
+    font-weight: var(--font-weight-semibold);
+    font-family: var(--font-general);
+}
+
+.no_data {
+    width: 100%;
+    padding: 3rem;
+    text-align: center;
+    line-height: 1.5rem;
+    color: var(--color-text-sub);
+    font-size: var(--text-lg);
+}
+
+::-webkit-scrollbar {
+    display: none;
+}
+
+
+.algorithmList{
+    display: grid;
+	grid-template-columns: repeat(1, 1fr);
+    gap: 1rem;
+    padding: 1rem;
+}
+
+@media (min-width: 720px) {
+    .algorithmList {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (min-width: 1296px) {
+    .algorithmList {
+        grid-template-columns: repeat(3, 1fr);
+    }
+}
+
+@media (min-width: 1440px) {
+    .algorithmList {
+        grid-template-columns: repeat(4, 1fr);
+    }
+}

--- a/src/pages/RightPages/MyPage/MorePage/AlgorithmMorePage.module.css
+++ b/src/pages/RightPages/MyPage/MorePage/AlgorithmMorePage.module.css
@@ -1,5 +1,8 @@
 .algorithmSection{
     padding: 1rem 2rem;
+
+    container-type: inline-size; 
+    container-name: algorithm_section;
 }
 
 .algorithmMore{
@@ -35,20 +38,14 @@
     padding: 1rem;
 }
 
-@media (min-width: 720px) {
+@container algorithm_section (min-width: 600px) {
     .algorithmList {
         grid-template-columns: repeat(2, 1fr);
     }
 }
 
-@media (min-width: 1296px) {
+@container algorithm_section (min-width: 900px) {
     .algorithmList {
         grid-template-columns: repeat(3, 1fr);
-    }
-}
-
-@media (min-width: 1440px) {
-    .algorithmList {
-        grid-template-columns: repeat(4, 1fr);
     }
 }

--- a/src/pages/RightPages/MyPage/MorePage/AlgorithmMorePage.tsx
+++ b/src/pages/RightPages/MyPage/MorePage/AlgorithmMorePage.tsx
@@ -1,0 +1,73 @@
+import { Sidebar } from "../../../../layouts/SidebarLayout/SidebarLayout";
+import BasicHeader from "../../../../layouts/Components/BasicHeader";
+import BaseLayout from "../../../../layouts/BaseLayout/BaseLayout";
+import styles from "./AlgorithmMorePage.module.css";
+
+//icons
+import { BsPinAngleFill } from "react-icons/bs";
+
+//components
+import LeftSide from "../../../LeftPages/Mainpage/MainPageLeft";
+import Button from "../../../../components/Button/Button";
+import AlgorithmBox from "../Components/AlgorithmBox/AlgorithmBox";
+
+const MainPage = () => {
+  const langs = ["Python", "C/C++", "JavaScript", "C#", "Go"];
+  const algorithms = [
+    "네이버 대비 알고리즘",
+    "알고리즘 연습",
+    "PS 연습",
+    "네이버 대비 알고리즘",
+    "알고리즘 연습",
+    "PS 연습",
+    "네이버 대비 알고리즘",
+    "알고리즘 연습",
+    "PS 연습",
+    "네이버 대비 알고리즘",
+    "알고리즘 연습",
+    "PS 연습",
+  ];
+
+  return (
+    <BaseLayout>
+      <Sidebar.Provider>
+        <Sidebar.Panel className={styles.panner}>
+          <LeftSide />
+        </Sidebar.Panel>
+
+        <Sidebar.Content header={<BasicHeader />}>
+          {/* 알고리즘 정보 */}
+          <section className={styles.algorithmSection}>
+            <Button className={styles.algorithmMore}>
+              <BsPinAngleFill /> 알고리즘 문제
+            </Button>
+            {algorithms.length > 0 ? (
+              <div className={styles.algorithmList}>
+                {algorithms.map((algorithm, i) => (
+                  <AlgorithmBox
+                    id={i + 1}
+                    key={"project" + i}
+                    title={algorithm}
+                    problems={["No 9995. 숫자 세기", "No 9995. 숫자 세기"]}
+                    duration={60}
+                    problemCount={2 * (i + 1)}
+                    lang={langs[i]}
+                    levelImg="/level_5.png"
+                  />
+                ))}
+              </div>
+            ) : (
+              <p className={styles.no_data}>
+                코딩 테스트 기록이 없습니다.
+                <br />
+                알고리즘 문제를 풀고 새로운 성장을 시작해보세요!
+              </p>
+            )}
+          </section>
+        </Sidebar.Content>
+      </Sidebar.Provider>
+    </BaseLayout>
+  );
+};
+
+export default MainPage;

--- a/src/pages/RightPages/MyPage/MorePage/CompanyMorePage.module.css
+++ b/src/pages/RightPages/MyPage/MorePage/CompanyMorePage.module.css
@@ -1,0 +1,40 @@
+.my_company_section, .all_company_section {
+    padding: 1rem 2rem;
+}
+
+.companyMore, .projectMore, .algorithmMore{
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.5rem;
+    
+    color: var(--color-text-primary);
+    font-size: var(--text-base);
+    font-weight: var(--font-weight-semibold);
+    font-family: var(--font-general);
+}
+
+.companyList {
+    display: grid;
+	grid-template-columns: repeat(1, 1fr);
+    gap: 0.5rem;
+    padding: 1rem;
+}
+
+@media (min-width: 720px) {
+    .companyList {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (min-width: 1290px) {
+    .companyList {
+        grid-template-columns: repeat(3, 1fr);
+    }
+}
+
+@media (min-width: 1440px) {
+    .companyList {
+        grid-template-columns: repeat(4, 1fr);
+    }
+}

--- a/src/pages/RightPages/MyPage/MorePage/CompanyMorePage.tsx
+++ b/src/pages/RightPages/MyPage/MorePage/CompanyMorePage.tsx
@@ -1,0 +1,115 @@
+import { useState } from "react";
+import { Sidebar } from "../../../../layouts/SidebarLayout/SidebarLayout";
+import BasicHeader from "../../../../layouts/Components/BasicHeader";
+import BaseLayout from "../../../../layouts/BaseLayout/BaseLayout";
+import styles from "./CompanyMorePage.module.css";
+
+//icons
+import { BsPinAngleFill } from "react-icons/bs";
+
+//components
+import LeftSide from "../../../LeftPages/Mainpage/MainPageLeft";
+import Button from "../../../../components/Button/Button";
+import FullCompanyBox from "../Components/CompanyBox/FullCompanyBox";
+
+const dummyCompanies = [
+  { id: 1, name: "네이버" },
+  { id: 2, name: "카카오" },
+  { id: 3, name: "라인" },
+  { id: 4, name: "쿠팡" },
+  { id: 5, name: "배민" },
+  { id: 6, name: "구름" },
+];
+
+const MainPage = () => {
+  const [myCompanies, setMyCompanies] = useState([]); //관심 기업 리스트 관리
+
+  // 액션 정의 - 관심 기업에 추가 or 삭제
+  const handleAction = (id: number, isFavorite: boolean) => {
+    if (isFavorite) {
+      // 이미 관심기업에 있다면 삭제
+      handleDelete(id);
+    } else {
+      // 관심 기업에 없었다면 추가
+      handleAdd(id);
+    }
+  };
+
+  //관심 기업에서 삭제
+  const handleDelete = (id: number) => {
+    setMyCompanies((prev) => prev.filter((company) => company.id !== id));
+  };
+
+  //관심 기업에 추가
+  const handleAdd = (id: number) => {
+    const companyToAdd = dummyCompanies.find((company) => company.id === id);
+    if (!companyToAdd) return;
+
+    setMyCompanies((prev) => {
+      // 중복 추가 방지
+      if (prev.find((c) => c.id === id)) return prev;
+      return [...prev, companyToAdd];
+    });
+  };
+
+  return (
+    <BaseLayout>
+      <Sidebar.Provider>
+        <Sidebar.Panel className={styles.panner}>
+          <LeftSide />
+        </Sidebar.Panel>
+
+        <Sidebar.Content header={<BasicHeader />}>
+          {/* 관심 기업 */}
+          <section className={styles.my_company_section}>
+            <Button className={styles.companyMore}>
+              <BsPinAngleFill /> 관심 기업
+            </Button>
+            <div className={styles.companyList}>
+              {myCompanies.map((company, i) => {
+                return (
+                  <FullCompanyBox
+                    key={"myCompany" + i}
+                    id={company.id}
+                    thumbnail="/logo_goorm.png"
+                    name={company.name}
+                    onHandle={handleAction}
+                    isFavorite={true}
+                  />
+                );
+              })}
+            </div>
+          </section>
+
+          {/* 전체 기업 */}
+          <section className={styles.all_company_section}>
+            <Button className={styles.companyMore}>
+              <BsPinAngleFill /> 전체 기업을 확인해보세요!
+            </Button>
+            <div className={styles.companyList}>
+              {dummyCompanies.map((company, i) => {
+                if (
+                  myCompanies.find((myCompany) => myCompany.id === company.id)
+                )
+                  return null;
+
+                return (
+                  <FullCompanyBox
+                    key={"company" + i}
+                    id={company.id}
+                    thumbnail="/logo_goorm.png"
+                    name={company.name}
+                    onHandle={handleAction}
+                    isFavorite={false}
+                  />
+                );
+              })}
+            </div>
+          </section>
+        </Sidebar.Content>
+      </Sidebar.Provider>
+    </BaseLayout>
+  );
+};
+
+export default MainPage;

--- a/src/pages/RightPages/MyPage/MorePage/ProjectMorePage.module.css
+++ b/src/pages/RightPages/MyPage/MorePage/ProjectMorePage.module.css
@@ -1,0 +1,54 @@
+.projectSection{
+    padding: 1rem 2rem;
+}
+
+.projectMore{
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.5rem;
+    
+    color: var(--color-text-primary);
+    font-size: var(--text-base);
+    font-weight: var(--font-weight-semibold);
+    font-family: var(--font-general);
+}
+
+.no_data {
+    width: 100%;
+    padding: 3rem;
+    text-align: center;
+    line-height: 1.5rem;
+    color: var(--color-text-sub);
+    font-size: var(--text-lg);
+}
+
+::-webkit-scrollbar {
+    display: none;
+}
+
+
+.projectList{
+    display: grid;
+	grid-template-columns: repeat(1, 1fr);
+    gap: 1rem;
+    padding: 1rem;
+}
+
+@media (min-width: 720px) {
+    .projectList {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (min-width: 1296px) {
+    .projectList {
+        grid-template-columns: repeat(3, 1fr);
+    }
+}
+
+@media (min-width: 1440px) {
+    .projectList {
+        grid-template-columns: repeat(4, 1fr);
+    }
+}

--- a/src/pages/RightPages/MyPage/MorePage/ProjectMorePage.module.css
+++ b/src/pages/RightPages/MyPage/MorePage/ProjectMorePage.module.css
@@ -1,5 +1,8 @@
 .projectSection{
     padding: 1rem 2rem;
+
+    container-type: inline-size; 
+    container-name: project_section;
 }
 
 .projectMore{
@@ -35,20 +38,14 @@
     padding: 1rem;
 }
 
-@media (min-width: 720px) {
+@container project_section (min-width: 600px) {
     .projectList {
         grid-template-columns: repeat(2, 1fr);
     }
 }
 
-@media (min-width: 1296px) {
+@container project_section (min-width: 900px) {
     .projectList {
         grid-template-columns: repeat(3, 1fr);
-    }
-}
-
-@media (min-width: 1440px) {
-    .projectList {
-        grid-template-columns: repeat(4, 1fr);
     }
 }

--- a/src/pages/RightPages/MyPage/MorePage/ProjectMorePage.tsx
+++ b/src/pages/RightPages/MyPage/MorePage/ProjectMorePage.tsx
@@ -1,0 +1,73 @@
+import { Sidebar } from "../../../../layouts/SidebarLayout/SidebarLayout";
+import BasicHeader from "../../../../layouts/Components/BasicHeader";
+import BaseLayout from "../../../../layouts/BaseLayout/BaseLayout";
+import styles from "./ProjectMorePage.module.css";
+
+//icons
+import { BsPinAngleFill } from "react-icons/bs";
+
+//components
+import LeftSide from "../../../LeftPages/Mainpage/MainPageLeft";
+import Button from "../../../../components/Button/Button";
+import ProjectBox from "../Components/ProjectBox/ProjectBox";
+
+const MainPage = () => {
+  const projectContents =
+    "이것은 구름 딥다이브의 지정 프로젝트인 Web IDE 개발을 위한 디자인입니다. ";
+  const langs = ["Python", "C/C++", "JavaScript", "C#", "Go"];
+
+  const projects = [
+    "구름 프로젝트",
+    "구름구름 프로젝트",
+    "프로젝트 이름",
+    "구름 프로젝트",
+    "구름구름 프로젝트",
+    "프로젝트 이름",
+    "구름 프로젝트",
+    "구름구름 프로젝트",
+    "프로젝트 이름",
+    "구름 프로젝트",
+    "구름구름 프로젝트",
+    "프로젝트 이름",
+  ];
+
+  return (
+    <BaseLayout>
+      <Sidebar.Provider>
+        <Sidebar.Panel className={styles.panner}>
+          <LeftSide />
+        </Sidebar.Panel>
+
+        <Sidebar.Content header={<BasicHeader />}>
+          {/* 프로젝트 정보 */}
+          <section className={styles.projectSection}>
+            <Button className={styles.projectMore}>
+              <BsPinAngleFill /> 대표 프로젝트
+            </Button>
+            {projects.length > 0 ? (
+              <div className={styles.projectList}>
+                {projects.map((project, i) => (
+                  <ProjectBox
+                    id={i}
+                    key={"project" + i}
+                    title={project}
+                    contents={projectContents.repeat(i + 1)}
+                    lang={langs[i % 5]}
+                  />
+                ))}
+              </div>
+            ) : (
+              <p className={styles.no_data}>
+                대표 프로젝트가 없습니다
+                <br />
+                깃허브에서 새로운 프로젝트를 불러와보세요!
+              </p>
+            )}
+          </section>
+        </Sidebar.Content>
+      </Sidebar.Provider>
+    </BaseLayout>
+  );
+};
+
+export default MainPage;


### PR DESCRIPTION
## 작업 내용
* 관심 기업/대표 프로젝트/알고리즘 더보기 페이지 디자인
* 메인페이지에서 더보기 페이지로 네이게이션 연결

## 전달 사항
* AlgoLeft.tsx에서 LogoDemo를 삭제하고 LeftPart 적용
-> 중복 코드를 LeftPart로 컴포넌트화하면서 로고 Team! jandi에도 다크/화이트 모드를 적용하기 위해 `logoDemo`를 삭제하고 다른 이미지 파일 `logo_white`, `logo_black`으로 대체했었습니다. 기존 것을 쓰기엔 뭔가 이미지 여백이 다르더라구요.... 근데 `AlgoLeft`에서 그 이미지 파일을 사용하고 있어 에러가 나고 있어서 급히 pr올립니다! 이미지 파일 `LogoDemo` 쓰던 부분을 제거하고 LeftPart 임포트해서 쓰는 걸로 수정했습니다
* 그리드 부분이 좀 더 자연스럽게 반응형 디자인되도록 미디어쿼리에서 컨테이너쿼리로 수정했습니다
* 전반적으로 중복 코드가 많은데,,, 이전 여행 플젝 보니까 섹션별로 따로 파일분리했더라구요 그래야 하나 고민중입니다