### PR TITLE
Feat: 로그인 기능 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import LoginPage from "./pages/Auth/Login/LoginPage";
 import Regitster_lang from "./pages/Auth/Register/SelectLanguagePage";
 import Regitster_company from "./pages/Auth/Register/SelectCompanyPage";
 import Regitster_done from "./pages/Auth/Register/DonePage";
+import LoginCallback from "./pages/Auth/Login/LoginCallback";
 
 // 메인 페이지
 import MainPage from "./pages/RightPages/MyPage/MainPage/MainPage";
@@ -33,6 +34,7 @@ function App() {
 
           {/* 로그인 & 회원가입 */}
           <Route path="/login" element={<LoginPage />} />
+          <Route path="/callback" element={<LoginCallback />} />
           <Route path="/register/language" element={<Regitster_lang />} />
           <Route path="/register/company" element={<Regitster_company />} />
           <Route path="/register/done" element={<Regitster_done />} />

--- a/src/hooks/useEffectOnce.tsx
+++ b/src/hooks/useEffectOnce.tsx
@@ -1,0 +1,13 @@
+import { useEffect, useRef } from "react";
+
+const useEffectOnce = (effect: React.EffectCallback) => {
+  const isMounted = useRef(false);
+
+  useEffect(() => {
+    if (isMounted.current) return;
+    isMounted.current = true;
+    return effect();
+  }, [effect]);
+};
+
+export default useEffectOnce;

--- a/src/pages/Auth/Login/LoginButton.tsx
+++ b/src/pages/Auth/Login/LoginButton.tsx
@@ -6,18 +6,17 @@ const LoginButton = () => {
   const { isDarkMode } = useDarkModeContext();
 
   // 로그인 버튼 클릭 시 로그인 or 회원가입 진행
-  const handleLogin = () => {
+  const handleLogin = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
     console.log("클릭됨");
-    // 만약 기존회원이라면 로그인 진행
     const clientId = import.meta.env.VITE_GITHUB_CLIENT_ID;
-    console.log(clientId);
-    // const redirectUri = import.meta.env.VITE_RED_URL;
 
+    // 깃허브 로그인으로 리다이렉트
     window.location.href = `https://github.com/login/oauth/authorize?client_id=${clientId}`;
   };
 
   return (
-    <Button onClick={handleLogin}>
+    <Button onClick={(e) => handleLogin(e)}>
       <div className={styles.inner}>
         <img
           className={styles.github_logo}

--- a/src/pages/Auth/Login/LoginButton.tsx
+++ b/src/pages/Auth/Login/LoginButton.tsx
@@ -1,19 +1,19 @@
-import { useNavigate } from "react-router-dom";
 import styles from "./LoginButton.module.css";
 import Button from "../../../components/Button/Button";
 import { useDarkModeContext } from "../../../contexts/DarkmodeContext";
 
 const LoginButton = () => {
-  const navigate = useNavigate();
   const { isDarkMode } = useDarkModeContext();
 
   // 로그인 버튼 클릭 시 로그인 or 회원가입 진행
   const handleLogin = () => {
+    console.log("클릭됨");
     // 만약 기존회원이라면 로그인 진행
-    // 로그인 진행...
+    const clientId = import.meta.env.VITE_GITHUB_CLIENT_ID;
+    console.log(clientId);
+    // const redirectUri = import.meta.env.VITE_RED_URL;
 
-    // 만약 신규 회원이라면 회원가입 진행
-    navigate("/register/language");
+    window.location.href = `https://github.com/login/oauth/authorize?client_id=${clientId}`;
   };
 
   return (

--- a/src/pages/Auth/Login/LoginCallback.tsx
+++ b/src/pages/Auth/Login/LoginCallback.tsx
@@ -1,31 +1,49 @@
-import { useEffect } from "react";
-// import { useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import axios from "axios";
+import useEffectOnce from "../../../hooks/useEffectOnce";
 
 const OAuthCallbackPage = () => {
-  useEffect(() => {
+  const navigate = useNavigate();
+  useEffectOnce(() => {
     const url = new URL(window.location.href);
     const code = url.searchParams.get("code");
     const base_url = import.meta.env.VITE_BASE_URL;
 
     if (code) {
-      // 백엔드에 code 전달
-      console.log(code);
+      // 백엔드에 code를 전달해서 토큰 받아오기
       axios
         .post(`${base_url}/users/login`, { code })
         .then((res) => {
-          // 로그인 성공 처리 (e.g. 토큰 저장, 페이지 이동)
-          localStorage.setItem("token", res.data.token);
-          console.log(res);
-          navigate("/mypage/setting");
-          // 만약 신규 회원이라면 회원가입 진행
-          // navigate("/register/language");
+          // 받아온 토큰 localStorage에 저장
+          localStorage.setItem("accessToken", res.data.accessToken);
+          localStorage.setItem("refreshToken", res.data.refreshToken);
+
+          // accessToken으로 유저 정보 가져오기
+          const accessToken = localStorage.getItem("accessToken");
+          return axios
+            .get(`${base_url}/users/me`, {
+              headers: {
+                Authorization: `Bearer ${accessToken}`,
+              },
+            })
+            .then((res) => {
+              console.log(res.data);
+
+              // 현재 소개란이 공란인지로 체크하지만, 추후 선호 기업/언어 연결되면 그걸로 바꿀 예정
+              if (res.data.introduction == null) {
+                console.log("신규 회원!");
+                navigate("/register/language");
+              } else {
+                console.log("기존 회원!");
+                navigate("/mypage/setting");
+              }
+            });
         })
         .catch((err) => {
           console.error(err);
         });
     }
-  }, []);
+  });
 
   return <div>로그인 중입니다...</div>;
 };

--- a/src/pages/Auth/Login/LoginCallback.tsx
+++ b/src/pages/Auth/Login/LoginCallback.tsx
@@ -1,0 +1,33 @@
+import { useEffect } from "react";
+// import { useNavigate } from "react-router-dom";
+import axios from "axios";
+
+const OAuthCallbackPage = () => {
+  useEffect(() => {
+    const url = new URL(window.location.href);
+    const code = url.searchParams.get("code");
+    const base_url = import.meta.env.VITE_BASE_URL;
+
+    if (code) {
+      // 백엔드에 code 전달
+      console.log(code);
+      axios
+        .post(`${base_url}/users/login`, { code })
+        .then((res) => {
+          // 로그인 성공 처리 (e.g. 토큰 저장, 페이지 이동)
+          localStorage.setItem("token", res.data.token);
+          console.log(res);
+          navigate("/mypage/setting");
+          // 만약 신규 회원이라면 회원가입 진행
+          // navigate("/register/language");
+        })
+        .catch((err) => {
+          console.error(err);
+        });
+    }
+  }, []);
+
+  return <div>로그인 중입니다...</div>;
+};
+
+export default OAuthCallbackPage;


### PR DESCRIPTION
## 작업 내용
* 로그인 기능 구현

## 전달 사항
* 깃허브로부터 받은 code는 일회용이기 때문에 개발자 모드에서도 한번만 랜더링되도록 useEffectOnce 추가
* LoginCallback에서 다음 페이지로 넘길 때 일단 임시적으로 소개란이 공란인지에 따라 언어설정 페이지 or 셋팅페이지로 가도록 했는데, 추후에 선호 언어 연결되면 그걸 기준으로 체크하도록 수정할 계획입니다