### PR TITLE
FEAT: 로그인 관련 리팩토링 및 axios 사용 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ dist
 dist-ssr
 *.local
 
+.env
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,7 @@
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import DarkModeProvider from "./contexts/DarkmodeProvider";
+import { PageEndPoints } from "./constants/api";
+
 import HomePage from "./pages/RightPages/MainPage/HomePage";
 import SettingPage from "./pages/RightPages/MyPage/SettingPage/SettingPage";
 import Test from "./pages/BasicPages/Test/Test";
@@ -30,32 +32,50 @@ function App() {
     <DarkModeProvider>
       <BrowserRouter>
         <Routes>
-          <Route path="/" element={<HomePage />} />
-          <Route path="/test" element={<Test />} />
-          <Route path="/chat/id" element={<ChatDetailPage />} />
+          <Route path={PageEndPoints.HOME} element={<HomePage />} />
+          <Route path={PageEndPoints.TEST} element={<Test />} />
 
           {/* 로그인 & 회원가입 */}
-          <Route path="/login" element={<LoginPage />} />
-          <Route path="/callback" element={<LoginCallback />} />
-          <Route path="/register/language" element={<Regitster_lang />} />
-          <Route path="/register/company" element={<Regitster_company />} />
-          <Route path="/register/done" element={<Regitster_done />} />
+          <Route path={PageEndPoints.LOGIN} element={<LoginPage />} />
+          <Route path={PageEndPoints.CALLBACK} element={<LoginCallback />} />
+          <Route
+            path={PageEndPoints.LOGIN_LANGUAGE}
+            element={<Regitster_lang />}
+          />
+          <Route
+            path={PageEndPoints.LOGIN_COMPANY}
+            element={<Regitster_company />}
+          />
+          <Route path={PageEndPoints.LOGIN_DONE} element={<Regitster_done />} />
 
-          {/* 메인페이지 */}
-          <Route path="/mypage" element={<MainPage />} />
-          <Route path="/mypage/company" element={<CompanyMorePage />} />
-          <Route path="/mypage/project" element={<ProjectMorePage />} />
-          <Route path="/mypage/algorithm" element={<AlgorithmMorePage />} />
-          <Route path="/mypage/setting" element={<SettingPage />} />
+          {/* 마이페이지 */}
+          <Route path={PageEndPoints.MYPAGE} element={<MainPage />} />
+          <Route
+            path={PageEndPoints.MY_COMPANY}
+            element={<CompanyMorePage />}
+          />
+          <Route
+            path={PageEndPoints.MY_PROJECT}
+            element={<ProjectMorePage />}
+          />
+          <Route path={PageEndPoints.MY_ALGO} element={<AlgorithmMorePage />} />
+          <Route path={PageEndPoints.SETTING} element={<SettingPage />} />
 
           {/* 채팅 */}
-          <Route path="/chat" element={<ChatMainPage />} />
+          <Route path={PageEndPoints.CHAT_MAIN} element={<ChatMainPage />} />
+          <Route
+            path={PageEndPoints.CHAT_DETAIL}
+            element={<ChatDetailPage />}
+          />
 
           {/* 알고리즘 */}
-          <Route path="/algo/company" element={<AlgorithmPage />} />
+          <Route path={PageEndPoints.ALGO_MAIN} element={<AlgorithmPage />} />
 
           {/* 코드편집기 */}
-          <Route path="/project/:id" element={<ProjectEditPage />} />
+          <Route
+            path={PageEndPoints.GITHUB_PROJECT}
+            element={<ProjectEditPage />}
+          />
         </Routes>
       </BrowserRouter>
     </DarkModeProvider>

--- a/src/apis/auth.tsx
+++ b/src/apis/auth.tsx
@@ -1,0 +1,56 @@
+import { APIEndPoints } from "../constants/api";
+import axiosInstance from "./axiosInstance";
+
+type AuthResponse = {
+  accessToken: string;
+  refreshToken: string;
+};
+
+const login = async (code: string): Promise<AuthResponse> => {
+  try {
+    const { data } = await axiosInstance.post(APIEndPoints.LOGIN, {
+      code: code,
+    });
+
+    if (!data.accessToken) {
+      throw new Error("로그인 실패");
+    }
+    return { accessToken: data.accessToken, refreshToken: data.refreshToken };
+  } catch {
+    throw new Error("로그인 오류");
+  }
+};
+
+const refreshAccessToken = async (refreshToken: string) => {
+  try {
+    const { data } = await axiosInstance.post(APIEndPoints.REFRESH, {
+      refreshToken: refreshToken,
+    });
+
+    return { accessToken: data.accessToken, refreshToken: data.refreshToken };
+  } catch {
+    throw new Error("토큰 리프레시 오류");
+  }
+};
+
+const getUserInfo = async () => {
+  try {
+    const accessToken = localStorage.getItem("accessToken");
+    if (!accessToken) throw new Error("AccessToken이 없습니다");
+
+    const data = await axiosInstance.get(APIEndPoints.MY_INFO);
+
+    return data;
+  } catch (err) {
+    console.log(err);
+    throw new Error("유저 정보 가져오기 오류");
+  }
+};
+
+const AuthService = {
+  login,
+  refreshAccessToken,
+  getUserInfo,
+};
+
+export default AuthService;

--- a/src/apis/axiosInstance.ts
+++ b/src/apis/axiosInstance.ts
@@ -1,0 +1,31 @@
+import axios from "axios";
+import { APIEndPoints } from "../constants/api";
+
+const BASE_URL = import.meta.env.VITE_BASE_URL;
+
+const axiosInstance = axios.create({
+  baseURL: BASE_URL,
+});
+
+const useHeaderEndPoints = new Set([`GET:${APIEndPoints.MY_INFO}`]);
+
+axiosInstance.interceptors.request.use((config) => {
+  const method = config.method?.toUpperCase();
+  const url = config.url;
+  const requestKey = `${method}:${url}`;
+
+  console.log("interceptor", { method, url, requestKey });
+
+  const isRequiredAuth = useHeaderEndPoints.has(requestKey);
+
+  console.log(isRequiredAuth);
+
+  if (isRequiredAuth) {
+    console.log("여기");
+    const accessToken = localStorage.getItem("accessToken") ?? "";
+    config.headers["Authorization"] = `Bearer ${accessToken}`;
+  }
+
+  return config;
+});
+export default axiosInstance;

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -1,0 +1,27 @@
+export const PageEndPoints = {
+  HOME: "/",
+  TEST: "/test",
+
+  LOGIN: "/login",
+  CALLBACK: "/callback",
+  LOGIN_LANGUAGE: "/register/language",
+  LOGIN_COMPANY: "/register/company",
+  LOGIN_DONE: "/register/done",
+
+  MYPAGE: "/mypage",
+  MY_COMPANY: "/mypage/company",
+  MY_PROJECT: "/mypage/project",
+  MY_ALGO: "/mypage/algorithm",
+  SETTING: "/mypage/setting",
+
+  CHAT_MAIN: "/chat",
+  CHAT_DETAIL: "/chat/:id",
+
+  ALGO_MAIN: "/algo",
+
+  GITHUB_PROJECT: "/project/:id",
+};
+
+export const APIEndPoints = {
+  LOGIN: "/users/login",
+};

--- a/src/constants/api.ts
+++ b/src/constants/api.ts
@@ -24,4 +24,6 @@ export const PageEndPoints = {
 
 export const APIEndPoints = {
   LOGIN: "/users/login",
+  REFRESH: "/users/refresh",
+  MY_INFO: "/users/me",
 };

--- a/src/hooks/useAxios.tsx
+++ b/src/hooks/useAxios.tsx
@@ -1,0 +1,46 @@
+import { useCallback, useState } from "react";
+import axiosInstance from "../apis/axiosInstance";
+import { AxiosRequestConfig, AxiosResponse } from "axios";
+
+/**
+ *
+ * @returns {{
+ *   loading: boolean,
+ *   isSuccess: boolean,
+ *   fetchData: (params?: Object) => Promise<void>;
+ * }}
+ */
+
+type UseAxiosReturn = {
+  loading: boolean;
+  isSuccess: boolean;
+  fetchData: (params: AxiosRequestConfig) => Promise<AxiosResponse | void>;
+};
+
+const useAxios = (): UseAxiosReturn => {
+  const [loading, setLoading] = useState<boolean>(false);
+  const [isSuccess, setIsSuccess] = useState<boolean>(false);
+
+  const fetchData = useCallback(async (params: AxiosRequestConfig) => {
+    setLoading(true);
+    setIsSuccess(false);
+
+    try {
+      const res = await axiosInstance.request({
+        ...params,
+        headers: {
+          ...params.headers,
+        },
+      });
+
+      setIsSuccess(true);
+      return res;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { loading, isSuccess, fetchData };
+};
+
+export default useAxios;

--- a/src/pages/Auth/Login/LoginCallback.tsx
+++ b/src/pages/Auth/Login/LoginCallback.tsx
@@ -1,48 +1,44 @@
 import { useNavigate } from "react-router-dom";
-import axios from "axios";
 import useEffectOnce from "../../../hooks/useEffectOnce";
+import AuthService from "../../../apis/auth";
+import { PageEndPoints } from "../../../constants/api";
 
 const OAuthCallbackPage = () => {
   const navigate = useNavigate();
+  const { login, getUserInfo } = AuthService;
+
   useEffectOnce(() => {
     const url = new URL(window.location.href);
     const code = url.searchParams.get("code");
-    const base_url = import.meta.env.VITE_BASE_URL;
 
-    if (code) {
-      // 백엔드에 code를 전달해서 토큰 받아오기
-      axios
-        .post(`${base_url}/users/login`, { code })
-        .then((res) => {
-          // 받아온 토큰 localStorage에 저장
-          localStorage.setItem("accessToken", res.data.accessToken);
-          localStorage.setItem("refreshToken", res.data.refreshToken);
+    const fetchLogin = async () => {
+      if (code) {
+        try {
+          const data = await login(code);
 
-          // accessToken으로 유저 정보 가져오기
-          const accessToken = localStorage.getItem("accessToken");
-          return axios
-            .get(`${base_url}/users/me`, {
-              headers: {
-                Authorization: `Bearer ${accessToken}`,
-              },
-            })
-            .then((res) => {
-              console.log(res.data);
+          // 토큰 저장
+          localStorage.setItem("accessToken", data.accessToken);
+          localStorage.setItem("refreshToken", data.refreshToken);
 
-              // 현재 소개란이 공란인지로 체크하지만, 추후 선호 기업/언어 연결되면 그걸로 바꿀 예정
-              if (res.data.introduction == null) {
-                console.log("신규 회원!");
-                navigate("/register/language");
-              } else {
-                console.log("기존 회원!");
-                navigate("/mypage/setting");
-              }
-            });
-        })
-        .catch((err) => {
-          console.error(err);
-        });
-    }
+          // 유저 정보 요청
+          const userInfo = await getUserInfo();
+
+          console.log(userInfo);
+
+          if (userInfo.data?.introduction == null) {
+            console.log("신규 회원!");
+            navigate(`${PageEndPoints.LOGIN_LANGUAGE}`);
+          } else {
+            console.log("기존 회원!");
+            navigate(`${PageEndPoints.HOME}`);
+          }
+        } catch (err) {
+          console.error("OAuth 로그인 에러", err);
+        }
+      }
+    };
+
+    fetchLogin();
   });
 
   return <div>로그인 중입니다...</div>;

--- a/src/pages/BasicPages/Test/Test.tsx
+++ b/src/pages/BasicPages/Test/Test.tsx
@@ -14,7 +14,18 @@ import {
   DropdownContent,
   DropdownTrigger,
 } from "../../../components/Dropdown/Dropdown";
+import useAxios from "../../../hooks/useAxios";
+import { useEffect } from "react";
+import { APIEndPoints } from "../../../constants/api";
 const Test = () => {
+  const { fetchData: getApi } = useAxios();
+
+  useEffect(() => {
+    getApi({ method: "GET", url: `${APIEndPoints.MY_INFO}` })
+      .then((res) => console.log(res))
+      .catch((err) => console.log(err));
+  }, [getApi]);
+
   return (
     <BaseLayout>
       <div className={styles.button_div}>
@@ -89,6 +100,7 @@ const Test = () => {
           </DropdownContent>
         </Dropdown>
       </div>
+      <div className={styles.button_div}></div>
     </BaseLayout>
   );
 };


### PR DESCRIPTION
### **작업내용**
- API포인트, PAGE포인트 구분 후 관리
- .env 파일 사용으로 인한 gitignore 수정
- axiosinstance 설정 및 header 필요 부분 interceptor 구현
- 로그인 관련 auth.ts 이용 리팩토링
- axios 이용관련 리팩토링 & test 페이지 테스트 케이스 추가

### **전달내용**
- axiosinstance에 useHeaderEndPoints안에 넣은 것들은 이제 로그인이 필요한 api들입니다. 로그인 이후 header에 토큰이 필요한 api 들은 이곳에 추가시켜서 토큰이 필요한 것들을 인터셉트하여 토큰을 넣어주고 axios를 통해 api 통신을 진행하게 해줍니다. 거의 대부분이 토큰이 필요한 api 이기 때문에 이에 따른 수정은 추후 진행 예정입니다.
- 로그인과 관련된 api들은 auth.tsx로 따로 두었습니다. 이 중 리프레시 토큰으로 accesstoken 재발행 부분은 추후 구현 예정입니다.
- test페이지에 /users/me를 예시로 hooks에 만들어 놓은 useAxios를 어떻게 사용하는지 적어뒀습니다. 이해 안가신다면 요 부분 한번 참고하시는거도 좋을거 같아요.