### PR TITLE
FEAT:  SidebarLayout resizer추가

### DIFF
--- a/src/layouts/SidebarLayout/SidebarLayout.module.css
+++ b/src/layouts/SidebarLayout/SidebarLayout.module.css
@@ -28,7 +28,7 @@
 }
 .content {
   flex: 1;
-  overflow-y: auto; 
+  overflow-y: auto;
   min-height: 100vh;
   box-sizing: border-box;
 }
@@ -41,4 +41,18 @@
 .full_width {
   max-width: none;
   margin: 0;
+}
+
+.resizer {
+  width: 6px;
+  background-color: transparent;
+  cursor: ew-resize;
+  position: relative;
+  z-index: 10;
+  transition: background-color 0.2s ease;
+}
+
+.resizer:hover,
+.resizer:active {
+  background-color: rgba(0, 0, 0, 0.1);
 }

--- a/src/pages/LeftPages/CodeTestPage/CodeTestLeft.module.css
+++ b/src/pages/LeftPages/CodeTestPage/CodeTestLeft.module.css
@@ -1,56 +1,60 @@
-.container{
-    color: var(--color-text-primary);
-    display: flex;
-    flex-direction: column;
-    gap: 2rem;
+.container {
+  color: var(--color-text-primary);
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
 }
 
-.prob{
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
+.prob {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
 }
 
-.prob_title{
-    font-weight: var(--font-weight-semibold);
-    font-size: var(--text-xl);
-    margin-bottom: 1rem;
-    gap: 0.5rem;
-    display: flex;
-    align-items: center;
+.prob_title {
+  font-weight: var(--font-weight-semibold);
+  font-size: var(--text-xl);
+  margin-bottom: 1rem;
+  gap: 0.5rem;
+  display: flex;
+  align-items: center;
 }
 
-.prob_content{
-    line-height: 1.4;
-    font-size: var(--text-lg);  
-    /* min-height: 20rem; */
+.prob_content {
+  line-height: 1.3;
+  font-size: var(--text-lg);
+
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  /* min-height: 20rem; */
 }
 
 .prob_reuirement {
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    font-size: var(--text-md);
-  }
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  font-size: var(--text-md);
+}
 
-  .testcase_card {
-    background-color: var(--color-bg-tertiary);
-    margin-bottom: 0.5rem;
-    font-family: monospace;
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    margin-bottom: 2rem;
-  }
+.testcase_card {
+  background-color: var(--color-bg-tertiary);
+  margin-bottom: 0.5rem;
+  font-family: monospace;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
 
-  .case_input{
-    width: 100%;
-    padding: 0.5rem;
-    background-color: var(--color-code-terminal);
-    line-height: 1.4;
-  }
-  
-.button_group{
-    display: flex;
-    justify-content: space-between;
+.case_input {
+  width: 100%;
+  padding: 0.5rem;
+  background-color: var(--color-code-terminal);
+  line-height: 1.4;
+}
+
+.button_group {
+  display: flex;
+  justify-content: space-between;
 }

--- a/src/pages/LeftPages/CodeTestPage/CodeTestLeft.tsx
+++ b/src/pages/LeftPages/CodeTestPage/CodeTestLeft.tsx
@@ -32,6 +32,9 @@ const ProjectLeft = ({
     if (currentIndex < problems.length - 1) setCurrentIndex(currentIndex + 1);
   };
 
+  if (!currentProblem) return null;
+  const arr = currentProblem.description.split("\n");
+
   return (
     <LeftPart>
       <div className={styles.container}>
@@ -46,7 +49,9 @@ const ProjectLeft = ({
                 />
               </div>
               <div className={styles.prob_content}>
-                {currentProblem.description}
+                {arr.map((line, idx) => (
+                  <p key={idx}>{line}</p>
+                ))}
               </div>
             </div>
             <div className={styles.prob_reuirement}>

--- a/src/pages/RightPages/AlgorithmPage/Test/CodeTestPage.tsx
+++ b/src/pages/RightPages/AlgorithmPage/Test/CodeTestPage.tsx
@@ -183,7 +183,11 @@ const CodeTestPage = () => {
           </div>
         </div>
       )}
-      <Sidebar.Provider className={styles.Code_layout}>
+      <Sidebar.Provider
+        className={styles.Code_layout}
+        minWidth={350}
+        maxWidth={700}
+      >
         <Sidebar.Panel>
           <LeftSide
             problems={problems}
@@ -191,7 +195,7 @@ const CodeTestPage = () => {
             setCurrentIndex={setCurrentIndex}
           />
         </Sidebar.Panel>
-
+        <Sidebar.Resizer />
         <Sidebar.Content fullWidth>
           <div className={styles.container}>
             {/* 헤더 - 시간, 종료버튼 */}


### PR DESCRIPTION
## 작업내용

- SidebarLayout의 Resizer를 추가하여, 코딩테스트 페이지에서 문재내용의 넓이를 최소350 ~ 최대700px까지 조절가능도록 수정했습니다.
- 문제내용의 글간격을 \n 기준으로 0.5rem을 추가했습니다.